### PR TITLE
Hotfix: Calendar Cleanup

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import { CalendarSettings } from './components/CalendarSettings';
 import { Profile } from './components/Profile';
 import { useProfile, useSpace } from './hooks';
 import './assets/styles/master.scss';
+import './assets/styles/react_dates_overrides.scss'
 
 // use Wally for empty app
 export const EmptyBodyRow = () => <WallySpinner />;

--- a/src/assets/styles/react_dates_overrides.scss
+++ b/src/assets/styles/react_dates_overrides.scss
@@ -1,0 +1,4 @@
+.DayPicker {
+    height: 255px;
+}
+

--- a/src/components/CalendarSettings.js
+++ b/src/components/CalendarSettings.js
@@ -21,14 +21,15 @@ export const CalendarSettings = () => {
   // useEffect will set code equal to the form when it loads or changes
   useEffect(() => {
     if (form) {
-      setConfigJSON(JSON.stringify(JSON.parse(form.description), null, 2));
-      setOrigConfigJSON(JSON.stringify(JSON.parse(form.description), null, 2));
+      // Calendar Config is a single attribute so we can use the intial index
+      setConfigJSON(JSON.stringify(JSON.parse(form.attributesMap['Calendar Config'][0]), null, 2));
+      setOrigConfigJSON(JSON.stringify(JSON.parse(form.attributesMap['Calendar Config'][0]), null, 2));
     }
   }, [form]);
 
   const onSave = () => {
-    const description = JSON.stringify(JSON.parse(configJSON));
-    updateConfig(kappSlug, formSlug, description);
+    const calendarConfig = JSON.stringify(JSON.parse(configJSON));
+    updateConfig(kappSlug, formSlug, calendarConfig);
   };
 
   return (

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { CoreForm } from '@kineticdata/react';
 import { useHistory, useParams, useLocation } from 'react-router-dom';
@@ -25,9 +25,11 @@ export const Form = ({ edit, profile }) => {
   const [formName, setFormName] = useState([]);
 
   // Set the Form Name when the form loads
-  const handleLoaded = form => {
-    setFormName(form.name());
-  };
+  const handleLoaded = useCallback(
+    ( form ) => 
+      setFormName(form.name()),
+    [],
+  );
 
   const handleCreated = useCallback(
     ({ submission }) => {

--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -16,7 +16,6 @@ import { connect } from 'react-redux';
 export { refetchCalendarEvents };
 
 export const handleMainDateSelect = props => args => {
-  console.log(args);
   let modalOpen;
   if (args == null) {
     modalOpen = false;

--- a/src/components/calendar/HelpText.js
+++ b/src/components/calendar/HelpText.js
@@ -50,7 +50,7 @@ export const NewDateForm = () => {
   const text = `
 "newDateForm": {
     "kappSlug": "calendar",
-    "fromSlug": "new-change",
+    "formSlug": "new-change",
     "fieldMapping": {
         "startDateTime": "Start Date Time"
     }

--- a/src/components/calendar/MainCalendar.js
+++ b/src/components/calendar/MainCalendar.js
@@ -63,7 +63,7 @@ export class MainCalendar extends Component {
       timezone: this.props.timezone,
     });
   };
-
+  
   componentDidUpdate(prevProps) {
     if (!this.props.selectedDate.isSame(prevProps.selectedDate)) {
       this.calendarRef.current
@@ -83,8 +83,8 @@ export class MainCalendar extends Component {
         agenda: 'listWeek',
       };
       this.calendarRef.current
-        .getApi()
-        .changeView(viewObject[this.props.mainCalendarView]);
+      .getApi()
+      .changeView(viewObject[this.props.mainCalendarView]);
     }
   }
 
@@ -97,6 +97,9 @@ export class MainCalendar extends Component {
         contentHeight={'auto'}
         eventLimit={this.props.maxEventLimit ? this.props.maxEventLimit : 3}
         defaultView="dayGridMonth"
+        // rerenderDelay will delay 1 sec in order for all rerenders of the calendar to finish
+        // this is used because of styling changes between rerenders and should be removed if those are fixed
+        rerenderDelay={1000}
         plugins={[
           dayGridPlugin,
           timeGridPlugin,

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -13,7 +13,7 @@ export const useForm = (kappSlug, formSlug) => {
 
   useEffect(() => {
     const fetchFormRequest = async () => {
-      const response = await fetchForm({ kappSlug, formSlug, include: 'details' });
+      const response = await fetchForm({ kappSlug, formSlug, include: 'details,attributesMap' });
       setForm(response.form);
     };
 
@@ -23,15 +23,13 @@ export const useForm = (kappSlug, formSlug) => {
   return form;
 };
 
-export const updateConfig = async (kappSlug, formSlug, description) => {
+export const updateConfig = async (kappSlug, formSlug, calendarConfig) => {
 
   const response = await formUpdate ({
     kappSlug: kappSlug,
     formSlug: formSlug,
-    form: { "description": description },
+    form: { attributesMap: { 'Calendar Config': [calendarConfig] } },
   });
-
-  console.log('RESP', response)
 }
 
 export const useKapp = kappSlug => {


### PR DESCRIPTION
Added a useCallback which was causing the calendar to not render half the time. Fixed a JS mapping issue with event call. Verified dateModal is working once newDateForm is implemented. Added a wrapper around the mini calendar so it has a fixed height on rerenders and doesn't bounce the layers underneath it. Added the rerenderDelay prop to the FullCalendar, this give it a 1 second delay to avoid showing multiple CSS changes during rerenders.