### PR TITLE
List View Hotfix

### DIFF
--- a/src/components/calendar/calendarHelpers.js
+++ b/src/components/calendar/calendarHelpers.js
@@ -307,7 +307,12 @@ export const getStartDate = (fieldObj, date, calendarView) => {
 
 export const getEndDate = (fieldObj, date, calendarView) => {
   // TODO: defaultView will have to be updated when adding the feature of changing the default view
-  const defaultView = calendarView ? calendarView : 'month';
+  let defaultView = calendarView ? calendarView : 'month';
+  // Currently list view is limited to a week timeframe, if that's ever expanded this
+  // will need to be updated to parse the type of list view being used.
+  if (defaultView === 'agenda') {
+    defaultView = 'week'
+  }
   return {
     [getPropertyName(fieldObj)]: moment(date)
       .endOf(defaultView)


### PR DESCRIPTION
getEndDate was not properly parsing the date type of calendarView agenda. The codebase currently only supports the listView as a week timeframe so I updated teh end date to change the agenda view to week for the end date. If anyone wants to impliment more than just a week listView they will need to add additional logic to parse different agenda timeframes.